### PR TITLE
fix: address all golangci-lint issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.26.3-alpine AS builder
 
 ARG TARGETARCH=arm64
 
-RUN wget https://github.com/upx/upx/releases/download/v5.1.1/upx-5.0.2-${TARGETARCH}_linux.tar.xz -O /tmp/upx.tar.xz && \
+RUN wget https://github.com/upx/upx/releases/download/v5.1.1/upx-5.1.1-${TARGETARCH}_linux.tar.xz -O /tmp/upx.tar.xz && \
     tar -xJOf /tmp/upx.tar.xz upx-5.1.1-${TARGETARCH}_linux/upx > /usr/local/bin/upx && \
     chmod +x /usr/local/bin/upx
 

--- a/eth/eth_test.go
+++ b/eth/eth_test.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"fmt"
 	"math/big"
 	"strings"
 	"testing"
@@ -43,7 +44,11 @@ func TestGetWalletAccount(t *testing.T) {
 			func() {
 				defer func() {
 					if r := recover(); r != nil {
-						err = r.(error)
+						if e, ok := r.(error); ok {
+							err = e
+						} else {
+							err = fmt.Errorf("panic: %v", r)
+						}
 					}
 				}()
 				account, privateKey, e := GetWalletAccount(tc.mnemonic, tc.hdPath)
@@ -308,7 +313,11 @@ func TestWalletDerivation(t *testing.T) {
 			func() {
 				defer func() {
 					if r := recover(); r != nil {
-						err = r.(error)
+						if e, ok := r.(error); ok {
+							err = e
+						} else {
+							err = fmt.Errorf("panic: %v", r)
+						}
 					}
 				}()
 

--- a/filler.go
+++ b/filler.go
@@ -88,7 +88,7 @@ func (s SubgraphDeployments) Swap(i, j int) {
 	s.deployments[i], s.deployments[j] = s.deployments[j], s.deployments[i]
 }
 
-func CreateSubgraphsPool(subgraphs []mgmt.SubgraphDeployment, indexingStatuses []mgmt.IndexingStatus, graphNetwork mgmt.GraphNetwork, minAllocation string) (SubgraphsPool, error) {
+func CreateSubgraphsPool(subgraphs []mgmt.SubgraphDeployment, indexingStatuses []mgmt.IndexingStatus, graphNetwork mgmt.GraphNetwork, _ string) (SubgraphsPool, error) {
 	subgraphDeployments := SubgraphDeployments{
 		deployments:  subgraphs,
 		graphNetwork: &graphNetwork,

--- a/funcs.go
+++ b/funcs.go
@@ -153,7 +153,7 @@ func printCostModels(costModels []mgmt.CostModel) error {
 	return nil
 }
 
-func status(ctx context.Context, agentHost string, networkSubgraph string, httpClient http.Client) error {
+func status(_ context.Context, agentHost string, networkSubgraph string, httpClient http.Client) error {
 	mgmtAPI := graphql.NewClient(agentHost, &httpClient)
 	gqlClient := mgmt.GraphService{Client: mgmtAPI}
 
@@ -259,7 +259,7 @@ func status(ctx context.Context, agentHost string, networkSubgraph string, httpC
 	return nil
 }
 
-func getIndexingRule(ctx context.Context, agentHost string, args []string, httpClient http.Client) error {
+func getIndexingRule(_ context.Context, agentHost string, args []string, httpClient http.Client) error {
 	if len(args) != 1 {
 		return errors.New("rules get requires one hash argument")
 	}
@@ -289,7 +289,7 @@ func getIndexingRule(ctx context.Context, agentHost string, args []string, httpC
 	return nil
 }
 
-func setIndexingRule(ctx context.Context, agentHost string, deploymentID string, args []string, httpClient http.Client) error {
+func setIndexingRule(_ context.Context, agentHost string, deploymentID string, args []string, httpClient http.Client) error {
 	mgmtAPI := graphql.NewClient(agentHost, &httpClient)
 	gqlClient := mgmt.GraphService{Client: mgmtAPI}
 	err := gqlClient.SetIndexingRule(deploymentID, args)
@@ -309,7 +309,7 @@ func setIndexingRule(ctx context.Context, agentHost string, deploymentID string,
 	return nil
 }
 
-func deleteIndexingRule(ctx context.Context, agentHost string, args []string, httpClient http.Client) error {
+func deleteIndexingRule(_ context.Context, agentHost string, args []string, httpClient http.Client) error {
 	if len(args) != 1 {
 		return errors.New("rules get requires one hash argument")
 	}
@@ -373,7 +373,67 @@ func setCostModel(agentHost string, deploymentID string, args []string, httpClie
 	return nil
 }
 
-func signals(ctx context.Context, networkSubgraph, indexNode string, httpClient http.Client) error {
+type signalTotals struct {
+	signalAmount    *big.Float
+	signalledTokens *big.Float
+	stakedTokens    *big.Float
+}
+
+func sumSubgraphSignals(deployments []mgmt.SubgraphDeployment) (signalTotals, error) {
+	one, _ := new(big.Float).SetString("1")
+	totals := signalTotals{
+		signalAmount:    big.NewFloat(0),
+		signalledTokens: big.NewFloat(0),
+		stakedTokens:    big.NewFloat(0),
+	}
+	for _, s := range deployments {
+		signal, ok := new(big.Float).SetString(s.SignalAmount)
+		if !ok {
+			return totals, errors.New("failed to convert signal amount to big.Float")
+		}
+		totals.signalAmount.Add(totals.signalAmount, signal)
+
+		signalled, ok := new(big.Float).SetString(s.SignalledTokens)
+		if !ok {
+			return totals, errors.New("failed to convert signalled tokens to big.Float")
+		}
+		if signalled.Cmp(one) < 1 {
+			fmt.Println("shitty graph ", s.ID)
+		}
+		totals.signalledTokens.Add(totals.signalledTokens, signalled)
+
+		staked, ok := new(big.Float).SetString(s.StakedTokens)
+		if !ok {
+			return totals, errors.New("failed to convert staked tokens to big.Float")
+		}
+		totals.stakedTokens.Add(totals.stakedTokens, staked)
+	}
+	return totals, nil
+}
+
+type subgraphMetrics struct {
+	signalAmount    *big.Float
+	signalledTokens *big.Float
+	stakedTokens    *big.Float
+}
+
+func parseSubgraphMetrics(s mgmt.SubgraphDeployment) (subgraphMetrics, error) {
+	signal, ok := new(big.Float).SetString(s.SignalAmount)
+	if !ok {
+		return subgraphMetrics{}, errors.New("failed to convert signal amount to big.Int")
+	}
+	signalled, ok := new(big.Float).SetString(s.SignalledTokens)
+	if !ok {
+		return subgraphMetrics{}, errors.New("failed to convert signal amount to big.Int")
+	}
+	staked, ok := new(big.Float).SetString(s.StakedTokens)
+	if !ok {
+		return subgraphMetrics{}, errors.New("failed to convert signal amount to big.Int")
+	}
+	return subgraphMetrics{signalAmount: signal, signalledTokens: signalled, stakedTokens: staked}, nil
+}
+
+func signals(_ context.Context, networkSubgraph, indexNode string, httpClient http.Client) error {
 	subgraphAPI := graphql.NewClient(networkSubgraph, &httpClient)
 	subgraphAPIClient := mgmt.GraphService{Client: subgraphAPI}
 	subgraphDeployments, err := subgraphAPIClient.GetSubgraphDeploymentsSignalled()
@@ -408,33 +468,13 @@ func signals(ctx context.Context, networkSubgraph, indexNode string, httpClient 
 		return errors.New("failed to convert signal amount to big.Float")
 	}
 	fmt.Println("graphNetwork: ", graphNetwork.TotalTokensAllocated, graphNetwork.TotalTokensSignalled)
-	totalSignalAmount := big.NewFloat(0)
-	zero, ok := new(big.Float).SetString("1")
-	if !ok {
-		return errors.New("failed to convert signal amount to big.Float")
+
+	totals, err := sumSubgraphSignals(subgraphDeployments)
+	if err != nil {
+		return err
 	}
-	totalSignalledTokens := big.NewFloat(0)
-	totalStakedTokens := big.NewFloat(0)
-	for _, s := range subgraphDeployments {
-		subgraphSignalAmount, ok := new(big.Float).SetString(s.SignalAmount)
-		if !ok {
-			return errors.New("failed to convert signal amount to big.Float")
-		}
-		totalSignalAmount = totalSignalAmount.Add(totalSignalAmount, subgraphSignalAmount)
-		subgraphSignalledTokens, ok := new(big.Float).SetString(s.SignalledTokens)
-		if !ok {
-			return errors.New("failed to convert signalled tokens to big.Float")
-		}
-		if subgraphSignalledTokens.Cmp(zero) < 1 {
-			fmt.Println("shitty graph ", s.ID)
-		}
-		totalSignalledTokens = totalSignalledTokens.Add(totalSignalledTokens, subgraphSignalledTokens)
-		subgraphStakedTokens, ok := new(big.Float).SetString(s.StakedTokens)
-		if !ok {
-			return errors.New("failed to convert signalled tokens to big.Float")
-		}
-		totalStakedTokens = totalStakedTokens.Add(totalStakedTokens, subgraphStakedTokens)
-	}
+	totalSignalAmount := totals.signalAmount
+	totalSignalledTokens := totals.signalledTokens
 
 	sort.SliceStable(subgraphDeployments, func(i, j int) bool {
 		numA, _ := new(big.Int).SetString(subgraphDeployments[i].SignalAmount, 10)
@@ -460,18 +500,13 @@ func signals(ctx context.Context, networkSubgraph, indexNode string, httpClient 
 			return err
 		}
 
-		subgraphSignalAmount, ok := new(big.Float).SetString(s.SignalAmount)
-		if !ok {
-			return errors.New("failed to convert signal amount to big.Int")
+		m, err := parseSubgraphMetrics(s)
+		if err != nil {
+			return err
 		}
-		subgraphSignalledTokens, ok := new(big.Float).SetString(s.SignalledTokens)
-		if !ok {
-			return errors.New("failed to convert signal amount to big.Int")
-		}
-		subgraphStakedTokens, ok := new(big.Float).SetString(s.StakedTokens)
-		if !ok {
-			return errors.New("failed to convert signal amount to big.Int")
-		}
+		subgraphSignalAmount := m.signalAmount
+		subgraphSignalledTokens := m.signalledTokens
+		subgraphStakedTokens := m.stakedTokens
 		percentageSignalAmount := fmt.Sprintf("%.2f", new(big.Float).Quo(subgraphSignalAmount, totalSignalAmount))
 		percentageSignalledTokens := fmt.Sprintf("%.2f", new(big.Float).Quo(subgraphSignalledTokens, totalSignalledTokens))
 
@@ -566,7 +601,7 @@ func signals(ctx context.Context, networkSubgraph, indexNode string, httpClient 
 	return nil
 }
 
-func getIndexingStatuses(ctx context.Context, indexNode string, httpClient http.Client) error {
+func getIndexingStatuses(_ context.Context, indexNode string, httpClient http.Client) error {
 	indexNodeAPI := graphql.NewClient(indexNode, &httpClient)
 	indexNodeAPIClient := mgmt.GraphService{Client: indexNodeAPI}
 	indexingStatuses, err := indexNodeAPIClient.GetIndexingStatuses()
@@ -746,7 +781,7 @@ func comparePoi(ctx context.Context, agentHost, indexNode, ethNode, networkSubgr
 	return nil
 }
 
-func getAllocation(ctx context.Context, ethNode, contractAddress, allocationID string) error {
+func getAllocation(_ context.Context, ethNode, contractAddress, allocationID string) error {
 	ethClient, err := ethclient.Dial(ethNode)
 	if err != nil {
 		return err
@@ -805,7 +840,7 @@ func getAllocation(ctx context.Context, ethNode, contractAddress, allocationID s
 	return nil
 }
 
-func closeAllocation(ctx context.Context, ethNode, contractAddress, mnemonic, hdWalletPath, allocationID, poi string) error {
+func closeAllocation(_ context.Context, ethNode, contractAddress, mnemonic, hdWalletPath, allocationID, poi string) error {
 	if (len(poi) != 3) && (len(poi) != 66) {
 		return errors.New("invalid POI provided")
 	}
@@ -894,7 +929,7 @@ func closeAllocation(ctx context.Context, ethNode, contractAddress, mnemonic, hd
 	return nil
 }
 
-func allocationsAdvice(ctx context.Context, networkSubgraph, indexNode string, stakeAmount decimal.Decimal, httpClient http.Client) error {
+func allocationsAdvice(_ context.Context, networkSubgraph, indexNode string, stakeAmount decimal.Decimal, httpClient http.Client) error {
 	subgraphAPI := graphql.NewClient(networkSubgraph, &httpClient)
 	subgraphAPIClient := mgmt.GraphService{Client: subgraphAPI}
 	subgraphDeployments, err := subgraphAPIClient.GetSubgraphDeploymentsSignalled()
@@ -1020,45 +1055,4 @@ func allocationsAdvice(ctx context.Context, networkSubgraph, indexNode string, s
 	fmt.Println("tokens left", tokensLeft)
 	fmt.Println("allocated:", allocatedSum)
 	return nil
-}
-
-func disableHighestOldRatio(subgraphsPool *SubgraphsPool, stakeAmount decimal.Decimal) {
-	for {
-		if len(*subgraphsPool) == 0 {
-			return
-		}
-
-		// Find the entity with the highest oldRatio
-		var maxOldRatioEntity *SubgraphsPoolEntity
-		var maxOldRatio decimal.Decimal
-		for i, s := range *subgraphsPool {
-			if s.Enabled {
-				oldRatio := s.StakedTokens.Div(s.Capacity)
-				if oldRatio.GreaterThan(maxOldRatio) {
-					maxOldRatio = oldRatio
-					maxOldRatioEntity = &(*subgraphsPool)[i]
-				}
-			}
-		}
-
-		// If no entity was found, return
-		if maxOldRatioEntity == nil {
-			return
-		}
-
-		// Calculate newRatio
-		oldRatio := maxOldRatioEntity.StakedTokens.Div(maxOldRatioEntity.Capacity)
-		ratioDiff := subgraphsPool.Ratio(stakeAmount).Sub(oldRatio)
-		allocationAmount := maxOldRatioEntity.Capacity.Mul(ratioDiff)
-		newRatio := maxOldRatioEntity.StakedTokens.Add(allocationAmount).Div(maxOldRatioEntity.Capacity)
-
-		// If oldRatio is bigger than newRatio, set Enabled to false and continue the loop
-		if oldRatio.GreaterThan(newRatio) {
-			maxOldRatioEntity.Enabled = false
-			continue
-		}
-
-		// If oldRatio is not bigger than newRatio, break the loop
-		break
-	}
 }

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -30,7 +30,6 @@ func (gs *GraphService) GetStatus(protocolNetwork string) (Status, error) {
 		IndexerAllocations []IndexerAllocation `graphql:"indexerAllocations(protocolNetwork: $protocolNetwork)"`
 	}
 	err := gs.Client.Query(context.Background(), &q, variables)
-
 	if err != nil {
 		return Status{}, err
 	}
@@ -258,7 +257,7 @@ func (gs *GraphService) GetSubgraphDeploymentsSignalled() ([]SubgraphDeployment,
 	return q.SubgraphDeployments, nil
 }
 
-func (gs *GraphService) GetSubgraphDeploymentById(deployment string) (SubgraphDeployment, error) {
+func (gs *GraphService) GetSubgraphDeploymentByID(deployment string) (SubgraphDeployment, error) {
 	variables := map[string]interface{}{
 		"deployment": graphql.String(deployment),
 	}

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -21,7 +21,7 @@ type mockQuerier struct {
 	err      error
 }
 
-func (m *mockQuerier) Query(ctx context.Context, q interface{}, variables map[string]interface{}) error {
+func (m *mockQuerier) Query(_ context.Context, q interface{}, _ map[string]interface{}) error {
 	if m.err != nil {
 		return m.err
 	}

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 		Name:       "indexing",
 		ShortUsage: "graph-indexer status indexing",
 		ShortHelp:  "Get subgraphs indexing statuses",
-		Exec: func(ctx context.Context, args []string) error {
+		Exec: func(ctx context.Context, _ []string) error {
 			return getIndexingStatuses(ctx, *indexNode, httpClient)
 		},
 	}
@@ -47,7 +47,7 @@ func main() {
 		ShortHelp:   "Check the status of an indexer",
 		Subcommands: []*ffcli.Command{statusIndexing},
 
-		Exec: func(ctx context.Context, args []string) error {
+		Exec: func(ctx context.Context, _ []string) error {
 			return status(ctx, *agentHost, *networkSubgraph, httpClient)
 		},
 	}
@@ -77,7 +77,7 @@ func main() {
 		ShortUsage: "graph-indexer rules start",
 		ShortHelp:  "Always index a deployment (and start indexing it if necessary)",
 		//	FlagSet:    stakeFlagSet,
-		Exec: func(_ context.Context, args []string) error {
+		Exec: func(_ context.Context, _ []string) error {
 			return nil
 		},
 	}
@@ -87,7 +87,7 @@ func main() {
 		ShortUsage: "graph-indexer rules stop",
 		ShortHelp:  "Never index a deployment (and stop indexing it if necessary)",
 		//	FlagSet:    stakeFlagSet,
-		Exec: func(_ context.Context, args []string) error {
+		Exec: func(_ context.Context, _ []string) error {
 			return nil
 		},
 	}
@@ -97,7 +97,7 @@ func main() {
 		ShortUsage: "graph-indexer rules clear",
 		ShortHelp:  "Clear one or more indexing rules",
 		//	FlagSet:    stakeFlagSet,
-		Exec: func(_ context.Context, args []string) error {
+		Exec: func(_ context.Context, _ []string) error {
 			return nil
 		},
 	}
@@ -137,7 +137,7 @@ func main() {
 		ShortUsage: "graph-indexer cost set variables",
 		ShortHelp:  "Update cost model variables",
 		//	FlagSet:    stakeFlagSet,
-		Exec: func(_ context.Context, args []string) error {
+		Exec: func(_ context.Context, _ []string) error {
 			return nil
 		},
 	}
@@ -146,7 +146,7 @@ func main() {
 		ShortUsage: "graph-indexer cost get <deploymentID>",
 		ShortHelp:  "Get cost models and/or variables for one or all subgraphs",
 		//	FlagSet:    stakeFlagSet,
-		Exec: func(_ context.Context, args []string) error {
+		Exec: func(_ context.Context, _ []string) error {
 			return getAllModelsWithVariables(*agentHost, httpClient)
 		},
 	}
@@ -157,7 +157,7 @@ func main() {
 		Subcommands: []*ffcli.Command{costSetModel, costSetVariables},
 
 		//	FlagSet:    stakeFlagSet,
-		Exec: func(_ context.Context, args []string) error {
+		Exec: func(_ context.Context, _ []string) error {
 			return nil
 		},
 	}
@@ -177,7 +177,7 @@ func main() {
 		Name:       "signals",
 		ShortUsage: "graph-indexer signals",
 		ShortHelp:  "Get list of subgraph deployments with signals",
-		Exec: func(ctx context.Context, args []string) error {
+		Exec: func(ctx context.Context, _ []string) error {
 			return signals(ctx, *networkSubgraph, *indexNode, httpClient)
 		},
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -86,7 +86,7 @@ func TestGetIndexingRule(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			client := newTestClient(func(req *http.Request) (*http.Response, error) {
+			client := newTestClient(func(_ *http.Request) (*http.Response, error) {
 				if tc.shouldError {
 					return nil, &mockHTTPError{message: "test error"}
 				}
@@ -430,10 +430,13 @@ func TestCreateSubgraphsPool(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			pool, _ := CreateSubgraphsPool(tc.subgraphDeployments, tc.indexingStatuses, mgmt.GraphNetwork{
+			pool, err := CreateSubgraphsPool(tc.subgraphDeployments, tc.indexingStatuses, mgmt.GraphNetwork{
 				TotalTokensSignalled: "1000",
 				TotalTokensAllocated: "500",
 			}, tc.minSignal)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if len(pool) != tc.expectedPoolSize {
 				t.Errorf("Expected pool size %d, got %d", tc.expectedPoolSize, len(pool))
 			}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -178,8 +178,8 @@ func TestCheckIdentifier(t *testing.T) {
 }
 
 func FuzzCheckIdentifier(f *testing.F) {
-	f.Fuzz(func(t *testing.T, s string) {
-		_ = CheckIdentifier(s) // Explicitly acknowledge return value
+	f.Fuzz(func(_ *testing.T, s string) {
+		_ = CheckIdentifier(s)
 	})
 }
 
@@ -238,7 +238,7 @@ func TestReturnIdentifier(t *testing.T) {
 }
 
 func FuzzReturnIdentifier(f *testing.F) {
-	f.Fuzz(func(t *testing.T, s string) {
-		ReturnIdentifier(s)
+	f.Fuzz(func(_ *testing.T, s string) {
+		_, _ = ReturnIdentifier(s) //nolint:errcheck
 	})
 }


### PR DESCRIPTION
- errcheck: use comma-ok type assertion in recover blocks, check error from CreateSubgraphsPool in tests, discard return values explicitly
- gofumpt: reformat graphql/graphql.go
- gocyclo: extract sumSubgraphSignals and parseSubgraphMetrics helpers from signals() to reduce cyclomatic complexity from 37 to ≤30
- revive/unused-param: rename unused ctx/args/req/t params to _ across funcs.go, filler.go, main.go, graphql_test.go, main_test.go, utils_test.go
- revive/var-naming: GetSubgraphDeploymentById → GetSubgraphDeploymentByID
- unused: delete dead disableHighestOldRatio function
- fix: correct upx tarball filename in Dockerfile